### PR TITLE
support logical backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ This file format should be key value like below
 APP_NAME=my_app
 TEST_HEROKU_APP_NAME=my_heroku_app_name
 DB_CONTAINER=postgres13
+STRATEGY=pull
 ```
+
+Available strategies are `pull` (default) and `logical-backup` for larger
+databases.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-db",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "DB scripts",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This is to split up the fetching and restoring of a database because `pull` will fail if the network times out even though you have pulled the data locally. I think this is recommend for larger databases under 20gb.