### PR TITLE
add heroku-capture-test into valid commands

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,9 @@ const VALID_COMMANDS = [{
   name: 'heroku-pull-test',
   script: './heroku/db-pull-test.sh'
 }, {
+  name: 'heroku-capture-test',
+  script: './heroku/db-capture-test.sh'
+}, {
   name: 'heroku-restore-test',
   script: './heroku/db-restore-test.sh'
 }, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-db",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "DB scripts",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Fixing error when execute `heroku-capture-test`

```
➜  svc-search git:(add_ioredis_types) ✗ yarn db:backup:capture:test            
yarn run v1.22.17
$ lib-db heroku-capture-test
Invalid command provided (heroku-capture-test), valid commands are (heroku-pull-test,heroku-restore-test,heroku-backup-test,heroku-pull-prod,snapshot,snapshot-restore,migrate-create,create,drop,schema)
```