### PR TITLE
fix: remove extra fi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-db",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "DB scripts",
   "main": "index.js",
   "bin": {

--- a/scripts/db-create.sh
+++ b/scripts/db-create.sh
@@ -23,7 +23,6 @@ if [ -z "$db_container" ]
     echo -e "${RED}Missing DB_CONTAINER env variable${NO_COLOR}"
     echo "Usage: lib-db create app_name db_container"
     exit 1
-    fi
 fi
 
 if [ -z "$DB" ]


### PR DESCRIPTION
Fix for error:
```bash
.../node_modules/@luxuryescapes/lib-db/scripts/db-create.sh: line 27: syntax error near unexpected token `fi`
error Command failed with exit code 2.
```