### PR TITLE
feat(heroku): allow certain tables to be excluded

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This file format should be key value like below
 APP_NAME=my_app
 TEST_HEROKU_APP_NAME=my_heroku_app_name
 DB_CONTAINER=postgres13
-EXCLUDE_TABLES="big_table;big_table_2"
+EXCLUDE_TABLES="big_table;big_table_2;personal\*"
 ```
 
 ## Usage
@@ -50,7 +50,7 @@ It will pull down the database from the heroku app named `test-svc-users` into a
 
 You can omit the arguments if you have `APP_NAME` and `TEST_HEROKU_APP_NAME` defined in your `.lib-db.config` file
 
-You can omit tables by setting the `EXCLUDE_TABLES` env var in `.lib-db.config` this is a `;` seperated list of table names. Make sure you quote this list so the `;` character is escaped
+You can omit table table by setting the `EXCLUDE_TABLES` env var in `.lib-db.config` this is a `;` seperated list of table names. Make sure you quote this list so the `;` character is escaped. If you are using a wildcard `*` this will need to be explicitly escaped
 
 ### heroku-pull-prod
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This file format should be key value like below
 APP_NAME=my_app
 TEST_HEROKU_APP_NAME=my_heroku_app_name
 DB_CONTAINER=postgres13
+EXCLUDE_TABLES=big_table;big_table_2
 ```
 
 ## Usage
@@ -48,6 +49,8 @@ So for example if you do the following
 It will pull down the database from the heroku app named `test-svc-users` into a local db named `svc_users_development`
 
 You can omit the arguments if you have `APP_NAME` and `TEST_HEROKU_APP_NAME` defined in your `.lib-db.config` file
+
+You can omit tables by setting the `EXCLUDE_TABLES` env var in `.lib-db.config` this is a `;` seperated list of table names
 
 ### heroku-pull-prod
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This file format should be key value like below
 APP_NAME=my_app
 TEST_HEROKU_APP_NAME=my_heroku_app_name
 DB_CONTAINER=postgres13
-EXCLUDE_TABLES=big_table;big_table_2
+EXCLUDE_TABLES="big_table;big_table_2"
 ```
 
 ## Usage
@@ -50,7 +50,7 @@ It will pull down the database from the heroku app named `test-svc-users` into a
 
 You can omit the arguments if you have `APP_NAME` and `TEST_HEROKU_APP_NAME` defined in your `.lib-db.config` file
 
-You can omit tables by setting the `EXCLUDE_TABLES` env var in `.lib-db.config` this is a `;` seperated list of table names
+You can omit tables by setting the `EXCLUDE_TABLES` env var in `.lib-db.config` this is a `;` seperated list of table names. Make sure you quote this list so the `;` character is escaped
 
 ### heroku-pull-prod
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It will pull down the database from the heroku app named `test-svc-users` into a
 
 You can omit the arguments if you have `APP_NAME` and `TEST_HEROKU_APP_NAME` defined in your `.lib-db.config` file
 
-You can omit table table by setting the `EXCLUDE_TABLES` env var in `.lib-db.config` this is a `;` seperated list of table names. Make sure you quote this list so the `;` character is escaped. If you are using a wildcard `*` this will need to be explicitly escaped
+You can omit table data by setting the `EXCLUDE_TABLES` env var in `.lib-db.config` this is a `;` seperated list of table names. Make sure you quote this list so the `;` character is escaped. If you are using a wildcard `*` this will need to be explicitly escaped
 
 ### heroku-pull-prod
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-db",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "DB scripts",
   "main": "index.js",
   "bin": {

--- a/scripts/heroku/db-pull-test-no-docker.sh
+++ b/scripts/heroku/db-pull-test-no-docker.sh
@@ -9,6 +9,12 @@ NO_COLOR='\033[0m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 
+exclude_tables_param=""
+if [ -n "$EXCLUDE_TABLES" ]
+  then
+  exclude_tables_param="--exclude-table-data=\"$EXCLUDE_TABLES\""
+fi
+
 if [ -z "$app" ]
   then
     echo -e "${RED}No app_name provided${NO_COLOR}"
@@ -34,7 +40,7 @@ echo -e "${GREEN}Dropping ${app}_development...${NO_COLOR}"
 dropdb --if-exists --port $dev_pg_port "${app}_development"
 
 echo -e "${GREEN}Pulling test DB from ${heroku_app} to ${app}_development${NO_COLOR}"
-heroku pg:pull DATABASE_URL "postgresql://@localhost:$dev_pg_port/${app}_development" --app $heroku_app
+heroku pg:pull DATABASE_URL "postgresql://@localhost:$dev_pg_port/${app}_development" --app $heroku_app $exclude_tables_param
 
 echo -e "${GREEN}We just pulled the test DB to ${app}_development
 You might like to run yarn db:snapshot, so you can later restore this fresh test DB without re-downloading it."

--- a/scripts/heroku/db-pull-test-no-docker.sh
+++ b/scripts/heroku/db-pull-test-no-docker.sh
@@ -12,7 +12,7 @@ RED='\033[0;31m'
 exclude_tables_param=""
 if [ -n "$EXCLUDE_TABLES" ]
   then
-  exclude_tables_param="--exclude-table-data=\"$EXCLUDE_TABLES\""
+    exclude_tables_param="--exclude-table-data=\"$EXCLUDE_TABLES\""
 fi
 
 if [ -z "$app" ]

--- a/scripts/heroku/db-pull-test.sh
+++ b/scripts/heroku/db-pull-test.sh
@@ -13,7 +13,7 @@ RED='\033[0;31m'
 exclude_tables_param=""
 if [ -n "$EXCLUDE_TABLES" ]
   then
-  exclude_tables_param="--exclude-table-data=\"$EXCLUDE_TABLES\""
+    exclude_tables_param="--exclude-table-data=\"$EXCLUDE_TABLES\""
 fi
 
 if [ -z "$app" ]

--- a/scripts/heroku/db-pull-test.sh
+++ b/scripts/heroku/db-pull-test.sh
@@ -18,16 +18,16 @@ fi
 
 if [ -z "$app" ]
   then
-  echo -e "${RED}No app_name provided${NO_COLOR}"
-  echo "Usage: lib-db heroku-pull-test app_name heroku_app_name"
-  exit 1
+    echo -e "${RED}No app_name provided${NO_COLOR}"
+    echo "Usage: lib-db heroku-pull-test app_name heroku_app_name"
+    exit 1
 fi
 
 if [ -z "$heroku_app" ]
   then
-  echo -e "${RED}No heroku_app_name provided${NO_COLOR}"
-  echo "Usage: lib-db heroku-pull-test app_name heroku_app_name"
-  exit 1
+    echo -e "${RED}No heroku_app_name provided${NO_COLOR}"
+    echo "Usage: lib-db heroku-pull-test app_name heroku_app_name"
+    exit 1
 fi
 
 copy_netrc_to_docker_container "$db_container"

--- a/scripts/heroku/db-pull-test.sh
+++ b/scripts/heroku/db-pull-test.sh
@@ -10,18 +10,24 @@ NO_COLOR='\033[0m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 
+exclude_tables_param=""
+if [ -n "$EXCLUDE_TABLES" ]
+  then
+  exclude_tables_param="--exclude-table-data=\"$EXCLUDE_TABLES\""
+fi
+
 if [ -z "$app" ]
   then
-    echo -e "${RED}No app_name provided${NO_COLOR}"
-    echo "Usage: lib-db heroku-pull-test app_name heroku_app_name"
-    exit 1
+  echo -e "${RED}No app_name provided${NO_COLOR}"
+  echo "Usage: lib-db heroku-pull-test app_name heroku_app_name"
+  exit 1
 fi
 
 if [ -z "$heroku_app" ]
   then
-    echo -e "${RED}No heroku_app_name provided${NO_COLOR}"
-    echo "Usage: lib-db heroku-pull-test app_name heroku_app_name"
-    exit 1
+  echo -e "${RED}No heroku_app_name provided${NO_COLOR}"
+  echo "Usage: lib-db heroku-pull-test app_name heroku_app_name"
+  exit 1
 fi
 
 copy_netrc_to_docker_container "$db_container"
@@ -31,7 +37,7 @@ echo -e "${GREEN}Dropping ${app}_development...${NO_COLOR}"
 docker exec -e PGUSER=postgres $db_container dropdb "${app}_development" --if-exists
 
 echo -e "${GREEN}Pulling test DB from ${heroku_app} to ${app}_development${NO_COLOR}"
-docker exec -e PGUSER=postgres $db_container heroku pg:pull DATABASE_URL "${app}_development" --app $heroku_app
+docker exec -e PGUSER=postgres $db_container heroku pg:pull DATABASE_URL "${app}_development" --app $heroku_app $exclude_tables_param
 
 echo -e "${GREEN}We just pulled the test DB to ${app}_development
 


### PR DESCRIPTION
Sometime heroku dbs are just too big

Now you can exclude the data from certain tables using `EXCLUDE_TABLES` in your config file